### PR TITLE
Adding support for csv and space-separated values

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,29 +30,44 @@ By default, the decoder packages looks for the struct tag "decoder". However, th
 
     struct Foo {
 
-     // populate the value from key "whatever" into FooField1
-     FooField1 string `decoder:"whatever"`
+        // populate the value from key "whatever" into FooField1
+        FooField1 string `decoder:"whatever"`
 
-     // skip populating FooField2, "-" signals skip
-     FooField2 string `decoder:"-"`
+        // skip populating FooField2, "-" signals skip
+        FooField2 string `decoder:"-"`
 
-     // this looks for a folder named FooField3
-     // and maps keys inside to the keys / values of the map.  string
-     // is the only valid key type, though the map value can be most any
-     // of the other types supported by this package.  Notable exception
-     // map, as nested maps are not allowed.  You can, however, have a
-     // map[string]SomeStruct.
-     FooField3 map[string]string
+        // this looks for a folder named FooField3
+        // and maps keys inside to the keys / values of the map.  string
+        // is the only valid key type, though the map value can be most any
+        // of the other types supported by this package.  Notable exception
+        // map, as nested maps are not allowed.  You can, however, have a
+        // map[string]SomeStruct.
+        FooField3 map[string]string
 
-     // this looks for a folder named FooField4 (case insensitive)
-     // this is similar to the map example above, but it ignores the keys
-     // inside and maps the values in-order into the slice.  nested slices
-     // are not allowed, i.e., [][]string.
-     FooField4 []string
+        // this looks for a folder named FooField4 (case insensitive)
+        // this is similar to the map example above, but it ignores the keys
+        // inside and maps the values in-order into the slice.  nested slices
+        // are not allowed, i.e., [][]string.
+        FooField4 []string
 
-     // this interprets the value of foofield5 as json data and
-     // will send it to json.Unmarshal from encoding/json package.
-     FooField5 *SomeStruct `decoder:"foofield5,json"`
+        // this interprets the value of foofield5 as json data and
+        // will send it to json.Unmarshal from encoding/json package.
+        FooField5 *SomeStruct `decoder:"foofield5,json"`
 
+        // this expects there to be a consul folder foofield6 and that the
+        // keys within will correspond to the fields inside SomeStruct type.
+        FooField6 *SomeStruct `decoder:"foofield6"`
+
+        // It is possible to specify arbitrarily nested values by giving
+        // the path in the struct tag.
+        FooField7 string `decoder:"arbitrarily/nested/key"`
+
+        // Comma separated values are supported.  This uses the encoding/csv
+        // package, so all variations supported by it are supported here.
+        FooField8 []string `decoder:",csv"
+
+        // Space separated values are supported.  This uses strings.Fields
+        // for parsing, so see that documentation for information.
+        FooField9 []string `decoder:",ssv"
 }
 ```

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -65,6 +65,7 @@ type tbConfig struct {
 	Duration        time.Duration
 	IPV4            net.IP
 	IPV6            net.IP
+	TestNestedValue string `decoder:"im/several/levels/deep/testnestedvalue"`
 
 	TestTextUnmarshaler *TestTextUnmarshaler
 
@@ -72,9 +73,13 @@ type tbConfig struct {
 
 	L1 *TestLevel1
 
-	NoTag     string
-	IgnoreMe  string `decoder:"-"`
-	ImSpecial string
+	NoTag           string
+	IgnoreMe        string `decoder:"-"`
+	ImSpecial       string
+	TestSpaceSepStr []string  `decoder:",ssv"`
+	TestCommaSepStr []*string `decoder:",csv"`
+	TestSpaceSepInt []int     `decoder:",ssv"`
+	TestCommaSepInt []int     `decoder:",csv"`
 }
 
 func makeServer(t *testing.T, cb testutil.ServerConfigCallback) *testutil.TestServer {
@@ -159,6 +164,8 @@ func (es *encoderTestSuite) TestUnmarshal() {
 		es.seed(client, "ipv4", "1.2.3.4")
 		es.seed(client, "ipv6", "::1")
 
+		es.seed(client, "im/several/levels/deep/testnestedvalue", "nestisthebest")
+
 		es.seed(client, "testbool", "true")
 
 		es.seed(client, "l1/uint", "1")
@@ -167,6 +174,10 @@ func (es *encoderTestSuite) TestUnmarshal() {
 		es.seed(client, "l1/level2/int", "-4")
 		es.seed(client, "l1/level2/level3/uint", "5")
 		es.seed(client, "l1/level2/level3/int", "-6")
+		es.seed(client, "testspacesepstr", "one two three")
+		es.seed(client, "testcommasepstr", "\"three, with embedded comma \"\"and quotes\"\"\",four,five")
+		es.seed(client, "testspacesepint", "1 2 3")
+		es.seed(client, "testcommasepint", "6,7,8")
 
 	})
 
@@ -193,6 +204,9 @@ func (es *encoderTestSuite) TestUnmarshal() {
 
 	tbc := &tbConfig{}
 	err = decoder.Unmarshal(prefix, kvs, tbc)
+	if err != nil {
+		es.T().Fatalf("shit: %s", err)
+	}
 	es.Assert().Nil(err, "unable to unmarshal: %s", err)
 
 	es.T().Log("keys ------")
@@ -238,12 +252,18 @@ func (es *encoderTestSuite) TestUnmarshal() {
 	es.Assert().True(ipv4.Equal(tbc.IPV4))
 	es.Assert().True(ipv6.Equal(tbc.IPV6))
 
+	es.Assert().Equal("nestisthebest", tbc.TestNestedValue)
 	es.Assert().Equal(tbc.L1.Uint, uint(1))
 	es.Assert().Equal(tbc.L1.Int, int(-2))
 	es.Assert().Equal(tbc.L1.Level2.Uint, uint64(3))
 	es.Assert().Equal(tbc.L1.Level2.Int, int64(-4))
 	es.Assert().Equal(tbc.L1.Level2.Level3.Uint, uint32(5))
 	es.Assert().Equal(tbc.L1.Level2.Level3.Int, int32(-6))
+	es.Assert().Equal(len(tbc.TestCommaSepStr), 3)
+	es.Assert().Equal(*(tbc.TestCommaSepStr[0]), `three, with embedded comma "and quotes"`)
+	es.Assert().Equal(len(tbc.TestSpaceSepStr), 3)
+	es.Assert().Equal(len(tbc.TestSpaceSepInt), 3)
+	es.Assert().Equal(len(tbc.TestCommaSepInt), 3)
 
 	es.T().Log(string(payload))
 	es.T().Logf("netmask %s", tbc.TestMask.String())

--- a/doc.go
+++ b/doc.go
@@ -17,8 +17,8 @@
 //     net.IPMask
 //
 //     struct - nested struct by default implies a consul folder with the same name.
-//              if the tag modifier "json" is encountered, then the value of in the KV
-//              is unmarshaled as json using json.Unmarshal
+//              if the tag modifier "isJSON" is encountered, then the value of in the KV
+//              is unmarshaled as isJSON using isJSON.Unmarshal
 //
 //     slice - the type can be most of the supported types, except another slice.
 //
@@ -38,7 +38,10 @@
 // but this is configurable in the Decoder struct.  the tag "-" indicates to
 // skip the field.  The modifier ",json" appended to the end
 // signals that the value is to be interpreted as json and unmarshaled rather
-// than interpreted.
+// than interpreted.  Similarly, the modififier ",csv" allows comma separated
+// values to be read into a slice, and ",ssv" allows space separated values
+// to be read intoa  slice.  For csv and ssv, slices of string, numeric and
+// boolean are supported.
 //
 //     struct Foo {
 //
@@ -62,14 +65,25 @@
 //         // are not allowed, i.e., [][]string.
 //         FooField4 []string
 //
-//         // this interprets the value of foofield5 as json data and
-//         // will send it to json.Unmarshal from encoding/json package.
+//         // this interprets the value of foofield5 as isJSON data and
+//         // will send it to isJSON.Unmarshal from encoding/isJSON package.
 //         FooField5 *SomeStruct `decoder:"foofield5,json"`
 //
 //         // this expects there to be a consul folder foofield6 and that the
 //         // keys within will correspond to the fields inside SomeStruct type.
 //         FooField6 *SomeStruct `decoder:"foofield6"`
 //
+//			// It is possible to specify arbitrarily nested values by giving
+//			// the path in the struct tag.
+//			FooField7 string `decoder:"arbitrarily/nested/key"`
+//
+//			// Comma separated values are supported.  This uses the encoding/csv
+//          // package, so all variations supported by it are supported here.
+//          FooField8 []string `decoder:",csv"
+//
+//          // Space separated values are supported.  This uses strings.Fields
+//          // for parsing, so see that documentation for information.
+//          FooField9 []string `decoder:",ssv"
 //
 //    }
 package decoder


### PR DESCRIPTION
Added csv and ssv modifiers to the struct tag parsing.

Uupdated documentation for ssv and csv

Removed stale TODO (was already protected by a mutex)

Added test coverage of the new features.